### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "Path::Router",
+    "license" : "Artistic-2.0",
     "version" : "0.1",
     "description" : "A tool for routing paths",
     "perl" : "6.c",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license